### PR TITLE
Minion needs isolating.

### DIFF
--- a/classes/controller/minion.php
+++ b/classes/controller/minion.php
@@ -5,7 +5,7 @@
  *
  * @author Matt Button <matthew@sigswitch.com>
  */
-class Controller_Minion extends Controller
+class Controller_Minion extends Kohana_Controller
 {
 	/**
 	 * The task to be executed 


### PR DESCRIPTION
Because minion makes use of the cascading file system, you get interference from class overloads. Here's an example.

I have a custom `Controller` that makes use of a table in my newest migration. If I want to test against an old database to see if the migrations work then minion will fail.

```
Database_Exception [ 0 ]: [1146] Table 'exchange.resources' doesn't exist ( 
        SELECT id, name, parent 
        FROM resources 
        ORDER BY (parent IS NOT NULL) ASC, parent DESC
) ~ MODPATH/database/classes/kohana/database/mysql.php [ 181 ]
```

_Code that runs in my overloaded controller_

I would have to roll-back the code to when it was using the old database schema; This is a lot of work when done frequently.

The solution would be to extend `Kohana_Controller` instead of `Controller`. There might be other places which need to be isolated.

Let me know what you think.
