### PR TITLE
fixing a bug with displaying help error messages

### DIFF
--- a/classes/controller/minion.php
+++ b/classes/controller/minion.php
@@ -62,7 +62,7 @@ class Controller_Minion extends Kohana_Controller
 			if ( ! class_exists($class))
 			{
 				echo View::factory('minion/help/error')
-					->set('error', 'Task "'.$task.'" does not exist');
+					->set('error', 'Task "'.$this->_task.'" does not exist');
 				
 				exit(1);
 			}


### PR DESCRIPTION
There was an undefined variable in the error message
