### PR TITLE
Fixed wrong task name for Kohana_Exception

### DIFF
--- a/classes/Kohana/Minion/Task.php
+++ b/classes/Kohana/Minion/Task.php
@@ -74,7 +74,7 @@ abstract class Kohana_Minion_Task {
 		{
 			throw new Kohana_Exception(
 				"Task ':task' is not a valid minion task",
-				array(':task' => get_class($task))
+				array(':task' => $class)
 			);
 		}
 


### PR DESCRIPTION
`get_class($task)` throws an Exception, because $task is not an object. Use $class instead.
