### PR TITLE
Updated guide/minion/tasks.md.

### DIFF
--- a/guide/minion/tasks.md
+++ b/guide/minion/tasks.md
@@ -6,7 +6,7 @@ Writing a task in minion is very easy. Simply create a new class called `Task_<T
 
 	class Task_Demo extends Minion_Task
 	{
-		protected $_defaults = array(
+		protected $_options = array(
 			'foo' = 'bar',
 			'bar' => NULL,
 		);


### PR DESCRIPTION
Updated the guide to properly state to use the $_options array instead of $_defaults for setting task options.

This is a fix for issue: http://dev.kohanaframework.org/issues/4512
