### PR TITLE
Accepted parameters are stored in the $_options array instead of $_defau...

### DIFF
--- a/guide/minion/tasks.md
+++ b/guide/minion/tasks.md
@@ -6,7 +6,7 @@ Writing a task in minion is very easy. Simply create a new class called `Task_<T
 
 	class Task_Demo extends Minion_Task
 	{
-		protected $_defaults = array(
+		protected $_options = array(
 			'foo' = 'bar',
 			'bar' => NULL,
 		);


### PR DESCRIPTION
I believe the documentation shows the wrong "array" for parameters the task can accept.
