### PR TITLE
Help text still has old syntax of --task={task}

### DIFF
--- a/classes/Kohana/Minion/Exception.php
+++ b/classes/Kohana/Minion/Exception.php
@@ -33,7 +33,7 @@ class Kohana_Minion_Exception extends Kohana_Exception {
 			{
 				echo Kohana_Exception::text($e);
 			}
-			
+
 			$exit_code = $e->getCode();
 
 			// Never exit "0" after an exception.
@@ -59,6 +59,6 @@ class Kohana_Minion_Exception extends Kohana_Exception {
 
 	public function format_for_cli()
 	{
-		return Kohana_Exception::text($e);
+		return Kohana_Exception::text($this);
 	}
 }

--- a/views/minion/help/list.php
+++ b/views/minion/help/list.php
@@ -13,5 +13,5 @@ Where {task} is one of the following:
 
 For more information on what a task does and usage details execute 
 
-    <?php echo $_SERVER['argv'][0]; ?> --task={task} --help
+    <?php echo $_SERVER['argv'][0]; ?> {task} --help
 


### PR DESCRIPTION
See http://dev.kohanaframework.org/issues/4752
