### PR TITLE
 Help text still has old syntax of --task={task}

### DIFF
--- a/views/minion/help/list.php
+++ b/views/minion/help/list.php
@@ -13,5 +13,5 @@ Where {task} is one of the following:
 
 For more information on what a task does and usage details execute 
 
-    <?php echo $_SERVER['argv'][0]; ?> --task={task} --help
+    <?php echo $_SERVER['argv'][0]; ?> {task} --help
 


### PR DESCRIPTION
_This issue has been moved here from http://dev.kohanaframework.org/issues/4752 and was also previously sent as PR #79._

The task list help text reads:

```
For more information on what a task does and usage details execute

index.php --task={task} --help
```

But these days it should be:

```
index.php {task} --help
```
