### PR TITLE
Undefined variable: e ~ MODPATH/minion/classes/Kohana/Minion/Exception.php [ 62 ]

### DIFF
--- a/classes/Kohana/Minion/Exception.php
+++ b/classes/Kohana/Minion/Exception.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 /**
- * Minipn exception
+ * Minion exception
  *
  * @package    Kohana
  * @category   Minion
@@ -33,7 +33,7 @@ class Kohana_Minion_Exception extends Kohana_Exception {
 			{
 				echo Kohana_Exception::text($e);
 			}
-			
+
 			$exit_code = $e->getCode();
 
 			// Never exit "0" after an exception.

--- a/classes/Kohana/Minion/Exception.php
+++ b/classes/Kohana/Minion/Exception.php
@@ -59,6 +59,6 @@ class Kohana_Minion_Exception extends Kohana_Exception {
 
 	public function format_for_cli()
 	{
-		return Kohana_Exception::text($e);
+		return Kohana_Exception::text($this);
 	}
 }


### PR DESCRIPTION
This pull request fixes the above error that's is thrown when you try to throw a Minion_Exception.

See [bug report 4774](http://dev.kohanaframework.org/issues/4774).
