### PR TITLE
Call to is_subclass_of() expects a string

### DIFF
--- a/classes/Kohana/Minion/Task.php
+++ b/classes/Kohana/Minion/Task.php
@@ -121,7 +121,7 @@ abstract class Kohana_Minion_Task {
 				array(':class' => $class)
 			);
 		}
-		elseif ( ! is_subclass_of($class, Minion_Task))
+		elseif ( ! is_subclass_of($class, 'Minion_Task'))
 		{
 			throw new Minion_Task_Exception(
 				'Class `:class` is not a valid minion task', 


### PR DESCRIPTION
Using the class name directly throws an exception:

ErrorException [ 8 ]: Use of undefined constant Minion_Task - assumed 'Minion_Task'

Verified by looking at PHP source directly which confirms this should a string:

ZEND_PARSE_PARAMETERS_START(2, 3)
        Z_PARAM_ZVAL(obj)
        Z_PARAM_STR(class_name)
        Z_PARAM_OPTIONAL
        Z_PARAM_BOOL(allow_string)
ZEND_PARSE_PARAMETERS_END();

Notice only the first argument is a zval, $class_name is a string.
