### PR TITLE
When associative array, $options[0] is undefined

### DIFF
--- a/classes/Kohana/Minion/Task.php
+++ b/classes/Kohana/Minion/Task.php
@@ -99,10 +99,10 @@ abstract class Kohana_Minion_Task {
 	 */
 	public static function factory(array $options = array())
 	{
-		if (isset($options['task']) OR isset($options[0]))
+		if (isset($options['task']) OR count($options))
 		{
 			// The first positional argument (aka 0) may be the task name
-			$task = Arr::get($options, 'task', $options[0]);
+			$task = Arr::get($options, 'task', reset($options));
 
 			unset($options['task'], $options[0]);
 		}

--- a/tests/minion/TaskTest.php
+++ b/tests/minion/TaskTest.php
@@ -68,4 +68,31 @@ class Minion_TaskTest extends Kohana_Unittest_TestCase {
 		$this->assertSame($expected, Minion_Task::convert_class_to_task($class));
 	}
 
+	/**
+	 * Provides test data for test_factory().
+	 *
+	 * @return array
+	 */
+    public function provider_factory()
+    {
+        return array(
+            array(array('task' => 'help')),
+            array(array('help')),
+        );
+    }
+
+	/**
+	 * Tests that the factory can instantiate with or without the --task CLI param
+	 *
+	 * @test
+	 * @covers Minion_Task::factory
+	 * @dataProvider provider_factory
+	 * @param array Options as would be returned from Minion_CLI::options
+	 */
+
+    public function test_factory($options)
+    {
+        $this->assertInstanceOf('Minion_Task', Minion_Task::factory($options));
+    }
+
 }


### PR DESCRIPTION
When $options contains the 'task' key in its associative array form, an exception will be thrown when trying to access $options[0]:

ErrorException [ 8 ]: Undefined offset: 0 ~ DOCROOT/vendor/kohana/minion/classes/Kohana/Minion/Task.php [ 105 ]

To replicate this independently of Minion's implementation, try running this:

php -r "echo ['task'=>'foo']['task'];"   // Will correctly print out "task"

php -r "echo ['task'=>'foo'][0];"  // Will throw PHP Notice:  Undefined offset: 0 in Command line code on line 1
