### PR TITLE
_execute() requires the declaration of $params

### DIFF
--- a/classes/Kohana/Minion/Task.php
+++ b/classes/Kohana/Minion/Task.php
@@ -287,9 +287,10 @@ abstract class Kohana_Minion_Task {
 	 * 
 	 * [!!] Override this method in current task.
 	 * 
+	 * @param  array $params The validated parameters passed from CLI
 	 * @return void
 	 */
-	abstract protected function _execute();
+	abstract protected function _execute(array $params);
 
 	/**
 	 * Outputs help for this task.

--- a/guide/minion/tasks.md
+++ b/guide/minion/tasks.md
@@ -12,16 +12,17 @@ Simply create a new class extending [Minion_Task] and call `Task_<Taskname>` in 
 
 		/**
 		 * This is a demo task.
-		 *
+		 * 
+		 * @param array $params Contains parameters passed from CLI
 		 * @return void
 		 */
-		protected function _execute()
+		protected function _execute(array $params)
 		{
-			if (empty($this->_options['bar']))
+			if (empty($params['bar']))
 			{
-				$this->_options['bar'] = Minion_CLI::read('Enter bar value');
+				$params['bar'] = Minion_CLI::read('Enter bar value');
 			}
-			Minion_CLI::write('Bar: '.$this->_options['bar']);
+			Minion_CLI::write('Bar: '.$params['bar']);
 		}
 
 	}


### PR DESCRIPTION
As can be seen in line 281, the execute() method is calling _execute() with the validated $options obtained from CLI.

We must declare this argument in the abstract function so that overriding Task classes are able to receive this array.

```
// Finally, run the task
$this->{$this->_method}($options);
```

The implementation in Minion has always been that "$this->_options" represents the list of available parameters with their default values. In runtime, "$params" represents the validated input from the user, or simply the default values in lieu of any input. 

I don't see a reason to introduce an API breaking change as part of this refactor.
